### PR TITLE
Add support for custom CHR graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ The following is a list of all configurable options:
   - 1536-byte palette file: similar to the 192-byte palette file format described above. Only the first 192 bytes are used, as the rest are used by emphasis bits which are not supported by Super Mario Bros.
 - Default: ""
 
+#### chr_file
+
+- Optional path to a raw 8KiB CHR graphics file that overrides the tile graphics loaded from the ROM. Use this to provide custom sprite art.
+- Default: ""
+
 #### scale
 
 - Controls the scale factor for rendered video.

--- a/source/Configuration.cpp
+++ b/source/Configuration.cpp
@@ -12,6 +12,7 @@ std::list<ConfigurationOption*> Configuration::configurationOptions = {
     &Configuration::paletteFileName,
     &Configuration::renderScale,
     &Configuration::romFileName,
+    &Configuration::chrFileName,
     &Configuration::scanlinesEnabled,
     &Configuration::vsyncEnabled
 };
@@ -56,6 +57,13 @@ BasicConfigurationOption<int> Configuration::renderScale(
  */
 BasicConfigurationOption<std::string> Configuration::romFileName(
     "game.rom_file", "Super Mario Bros. (JU) (PRG0) [!].nes"
+);
+
+/**
+ * Optional filename for CHR tile data override.
+ */
+BasicConfigurationOption<std::string> Configuration::chrFileName(
+    "video.chr_file", ""
 );
 
 /**
@@ -144,4 +152,9 @@ bool Configuration::getScanlinesEnabled()
 bool Configuration::getVsyncEnabled()
 {
     return vsyncEnabled.getValue();
+}
+
+const std::string& Configuration::getChrFileName()
+{
+    return chrFileName.getValue();
 }

--- a/source/Configuration.hpp
+++ b/source/Configuration.hpp
@@ -111,6 +111,11 @@ public:
     static const std::string& getPaletteFileName();
 
     /**
+     * Get the filename for an optional CHR tile override file.
+     */
+    static const std::string& getChrFileName();
+
+    /**
      * Get the desired ROM file name.
      */
     static const std::string& getRomFileName();
@@ -137,6 +142,7 @@ private:
     static BasicConfigurationOption<std::string> paletteFileName;
     static BasicConfigurationOption<int> renderScale;
     static BasicConfigurationOption<std::string> romFileName;
+    static BasicConfigurationOption<std::string> chrFileName;
     static BasicConfigurationOption<bool> scanlinesEnabled;
     static BasicConfigurationOption<bool> vsyncEnabled;
 

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -19,6 +19,38 @@ static SMBEngine* smbEngine = nullptr;
 static uint32_t renderBuffer[RENDER_WIDTH * RENDER_HEIGHT];
 
 /**
+ * Apply custom CHR graphics if configured.
+ */
+static void applyChrOverride()
+{
+    const std::string& chrFile = Configuration::getChrFileName();
+    if (chrFile.empty())
+    {
+        return;
+    }
+
+    FILE* file = fopen(chrFile.c_str(), "r");
+    if (file == NULL)
+    {
+        std::cout << "Failed to open CHR file \"" << chrFile << "\". Using ROM graphics.\n";
+        return;
+    }
+
+    fseek(file, 0L, SEEK_END);
+    size_t fileSize = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    if (fileSize < 8192)
+    {
+        std::cout << "CHR file \"" << chrFile << "\" is too small. Expected 8192 bytes." << std::endl;
+        fclose(file);
+        return;
+    }
+
+    fread(romImage + 16 + 2 * 16384, sizeof(uint8_t), 8192, file);
+    fclose(file);
+}
+
+/**
  * Load the Super Mario Bros. ROM image.
  */
 static bool loadRomImage()
@@ -68,6 +100,9 @@ static bool initialize()
     {
         return false;
     }
+
+    // Apply custom CHR graphics if configured
+    applyChrOverride();
 
     // Initialize SDL
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0)


### PR DESCRIPTION
## Summary
- add optional `video.chr_file` configuration option
- load CHR tile override file when initializing
- document new option in README

## Testing
- `cmake ..` *(fails: Unknown CMake command `FLEX_TARGET`)*

------
https://chatgpt.com/codex/tasks/task_e_6882c2275b24832f92fb802b60137755